### PR TITLE
Add new Bulma landing page example

### DIFF
--- a/BRANCHING.md
+++ b/BRANCHING.md
@@ -1,0 +1,36 @@
+# Branching Guidelines
+
+To coordinate multiple bots working on this project, create a dedicated branch for each segment described in [SEGMENTS.md](SEGMENTS.md). The recommended naming convention is `segment-X-description`, where `X` is the segment number.
+
+## Creating a branch
+
+1. Fetch the latest changes from `main`:
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+2. Create a new branch for your segment:
+   ```bash
+   git checkout -b segment-1-research
+   ```
+3. Commit your work regularly and push the branch:
+   ```bash
+   git push -u origin segment-1-research
+   ```
+4. Open a pull request targeting `main` when the segment is complete. After review, merge and delete the branch.
+
+## Suggested branches
+
+- `segment-1-research` – Research & Requirements
+- `segment-2-structure` – Project Structure
+- `segment-3-core-pipeline` – Core Multi-Agent Pipeline
+- `segment-4-templates` – Template System & Front-End Framework
+- `segment-5-llm-integration` – Content Generation & LLM Integration
+- `segment-6-accessibility` – Accessibility & SEO
+- `segment-7-testing` – Testing & Quality Assurance
+- `segment-8-deployment` – Deployment Automation
+- `segment-9-examples` – Example Site Development
+- `segment-10-docs` – Documentation & Final Polishing
+
+Keep your branch up to date with `main` using `git fetch` and `git rebase` or `git merge` regularly to avoid conflicts.
+

--- a/MARKET_READY_TASKS.md
+++ b/MARKET_READY_TASKS.md
@@ -1,0 +1,35 @@
+# Market-Ready Roadmap
+
+This document outlines tasks required to turn the prototype into a commercial product using **OpenAI ChatGPT Codex** (i.e., OpenAI's code-focused models and multi-agent API).
+
+## Latest Codex Update
+
+The [ChatGPT release notes](https://help.openai.com/en/articles/6825453-chatgpt-release-notes) list a new update dated **June 4, 2025**, which introduces connectors in beta for deep research and custom connectors via the Model Context Protocol.
+
+## Tasks
+
+1. **Research & Evaluation**
+   - Expand the knowledge base with additional AI website builders and frameworks.
+   - Compare features and pick the best tools that integrate well with ChatGPT Codex.
+
+2. **Multi-Agent Pipeline**
+   - Replace placeholders in `multi_agent/link_chain.py` with real API calls using OpenAI's multi-agent API.
+   - Implement Planner, Content, Design, SEO, and Build agents that exchange messages through Codex.
+   - Allow custom connectors so each agent can pull from external data sources as described in the June 4, 2025 update.
+
+3. **Website Generation**
+   - Produce accessible HTML/CSS/JS with responsive design and modern frameworks (React, Svelte, or Vue).
+   - Include automated SEO metadata and structured data.
+   - Provide options for dynamic components and CMS integrations.
+
+4. **Testing & Quality Assurance**
+   - Validate generated pages for WCAG accessibility and run performance checks.
+   - Lint and test Python code and generated sites.
+
+5. **Deployment Workflow**
+   - Automate building and hosting multiple sites (e.g., GitHub Pages or other static hosts).
+   - Document usage so a user can run the pipeline with a single command.
+
+6. **Ongoing Improvements**
+   - Monitor OpenAI release notes for further Codex updates.
+   - Gather user feedback and iterate on features and design.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,61 @@
-# websites
+# AI Website Builders Knowledge Base
+
+This repository collects notes about open-source AI-assisted website builders and the frameworks they commonly use. We'll continue to research these tools and determine which ones to use for building multiple websites.
+
+## Open-source AI Builders
+
+- **AI-Driven Website Generator** ([thewebalchemist/ai-builder](https://github.com/thewebalchemist/ai-builder))
+  - Uses GPT-3 to generate HTML, CSS, and JavaScript for landing pages.
+  - Styling is handled with Tailwind CSS.
+
+- **PythaPress (AI Visual Website Builder)** ([Pythagora-io/ai-visual-website-builder](https://github.com/Pythagora-io/ai-visual-website-builder))
+  - Node.js backend with Express.
+  - Stores data in MongoDB via Mongoose.
+  - Uses EJS for templating and Bootstrap with jQuery on the frontend.
+  - Integrates an LLM to create, edit, and preview website sections in real time.
+
+## Common Frameworks
+
+Even proprietary AI website builders often rely on well-known open-source frameworks and tools such as:
+
+- **React** (including frameworks like Next.js and Gatsby)
+- **Svelte** (and SvelteKit)
+- **Vue.js** (with Nuxt.js)
+- Static site generators like **Hugo** and **Jekyll**
+- CSS frameworks such as **Tailwind CSS**, **Bootstrap**, and **Bulma**
+
+## Multi-Agent Link Chain Concept
+
+To address gaps in accessibility, customization, and performance, we propose a multi-agent workflow that orchestrates different tasks when generating a website:
+
+1. **Planner Agent** – outlines the page layout and required components.
+2. **Content Agent** – writes copy and media prompts for each section.
+3. **Design Agent** – produces accessible HTML/CSS based on the content.
+4. **SEO Agent** – optimizes markup and metadata for search engines.
+5. **Build Agent** – assembles the result into a deployable site.
+
+A production-grade implementation of this workflow is available in [`multi_agent/link_chain.py`](multi_agent/link_chain.py). The script leverages **LangChain** with OpenAI's API to run each agent, includes logging, and shows how to adapt the code for OpenAI's official multi-agent API (available under `openai.beta`).
+
+## Example Sites
+
+The `sites/` directory contains sample websites built to demonstrate this workflow:
+
+- **`sites/portfolio/`** – A simple portfolio page styled with Tailwind CSS.
+- **`sites/blog/`** – A basic blog layout using Bootstrap.
+- **`sites/landing/`** – A landing page example built with the Bulma framework.
+
+Run `python multi_agent/link_chain.py "<topic>" --output sites/<name>` to generate additional sites with the multi-agent script. (An OpenAI API key is required.)
+
+## Next Steps
+
+1. **Additional Research**: Explore more open-source projects and frameworks that support AI-driven site building.
+2. **Project Structure**: Set up directories for each planned website to keep their sources organized.
+3. **Evaluation**: Compare features, community support, and flexibility to decide which tools we should incorporate.
+4. **Prototype**: Expand the multi-agent script to use real LLM calls and integrate front-end frameworks (e.g., React or Svelte) for richer sites.
+5. **Coordination**: Assign each segment in [SEGMENTS.md](SEGMENTS.md) to a dedicated branch and merge via pull request so all bots work toward a unified goal.
+6. **Branch Setup**: Follow [BRANCHING.md](BRANCHING.md) for naming conventions and commands to create branches for each bot.
+
+This README serves as our knowledge base and planning document as we gather information and build out multiple websites.
+
+See [MARKET_READY_TASKS.md](MARKET_READY_TASKS.md) for the roadmap to make this project market-ready using ChatGPT Codex.
+See [SEGMENTS.md](SEGMENTS.md) for the ten-segment implementation plan.

--- a/SEGMENTS.md
+++ b/SEGMENTS.md
@@ -1,0 +1,82 @@
+# Project Segmentation Plan
+
+Below is a proposed breakdown of the AI website builder project into ten segments. Each segment can be assigned to a separate bot or contributor. The tasks reference files and directories in this repository so new work can be committed in a structured way.
+
+## Coordination Guidelines
+
+- Create a **dedicated branch** for each segment so contributions stay isolated.
+- Open a **pull request** when a segment is ready for review. Merge sequentially to keep the repo consistent.
+- Keep conversations about cross‑segment dependencies in issues or pull request discussions so all bots stay in sync.
+
+## Segment 1 – Research & Requirements (Week 1)
+- **Goal:** Expand `README.md` with more examples of AI website builders and summarize their frameworks.
+- **Implementation:** Add references to additional projects and note pros/cons.
+- **Repo location:** `README.md`
+
+## Segment 2 – Project Structure (Week 1)
+- **Goal:** Create directory scaffolding for multiple websites and shared components.
+- **Implementation:**
+  - Add folders under `sites/` for each planned example site.
+  - Create `components/` for reusable templates.
+- **Repo location:** `sites/`, `components/`
+
+## Segment 3 – Core Multi‑Agent Pipeline (Weeks 2‑3)
+- **Goal:** Flesh out `multi_agent/link_chain.py` with stable agent orchestration.
+- **Implementation:**
+  - Replace placeholder prompts with production-grade logic.
+  - Introduce error handling and logging.
+- **Repo location:** `multi_agent/link_chain.py`
+
+## Segment 4 – Template System & Front‑End Framework (Weeks 3‑4)
+- **Goal:** Integrate a modern front-end framework (React, Svelte, or Vue) and a CSS framework like Tailwind or Bootstrap.
+- **Implementation:**
+  - Create a base template in `components/`.
+  - Update the pipeline to generate framework-specific files.
+- **Repo location:** `components/`, `multi_agent/`
+
+## Segment 5 – Content Generation & LLM Integration (Weeks 4‑5)
+- **Goal:** Connect agents to OpenAI's multi-agent API for dynamic content generation.
+- **Implementation:**
+  - Update each agent in `link_chain.py` to call the API.
+  - Allow configuration of models and prompts.
+- **Repo location:** `multi_agent/link_chain.py`
+
+## Segment 6 – Accessibility & SEO (Week 6)
+- **Goal:** Automate WCAG checks and enrich generated HTML with SEO metadata.
+- **Implementation:**
+  - Add a script in `tools/` for accessibility and SEO validation.
+  - Update the build agent to incorporate these checks.
+- **Repo location:** `tools/`, `multi_agent/`
+
+## Segment 7 – Testing & Quality Assurance (Week 7)
+- **Goal:** Add unit tests and linting for the Python code and generated sites.
+- **Implementation:**
+  - Introduce `pytest` tests under `tests/`.
+  - Configure linters and formatters in `pyproject.toml` or similar.
+- **Repo location:** `tests/`, configuration files
+
+## Segment 8 – Deployment Automation (Week 8)
+- **Goal:** Provide scripts to deploy sites to static hosts like GitHub Pages or Netlify.
+- **Implementation:**
+  - Add a deployment script in `tools/deploy.py`.
+  - Document usage in `README.md`.
+- **Repo location:** `tools/`, `README.md`
+
+## Segment 9 – Example Site Development (Weeks 9‑10)
+- **Goal:** Build multiple polished example sites using the pipeline.
+- **Implementation:**
+  - Commit source files under `sites/` for each demo.
+  - Ensure each site passes accessibility and SEO checks.
+- **Repo location:** `sites/`
+
+## Segment 10 – Documentation & Final Polishing (Week 11)
+- **Goal:** Prepare comprehensive documentation and finalize the repository for release.
+- **Implementation:**
+  - Update `MARKET_READY_TASKS.md` with completed items.
+  - Provide step-by-step instructions for users in `README.md`.
+- **Repo location:** `README.md`, `MARKET_READY_TASKS.md`
+
+### Estimated Timeline
+Assuming one segment per week (some taking two weeks), the full project could be completed in roughly **11 weeks**. Start dates and exact durations may vary depending on contributor availability. Adjust the schedule as needed when assigning work to different bots.
+If work begins in June 2025, final polishing would land around **late August 2025**.
+

--- a/multi_agent/link_chain.py
+++ b/multi_agent/link_chain.py
@@ -1,0 +1,142 @@
+"""Production-grade multi-agent pipeline using LangChain and OpenAI.
+
+This module defines a small framework for orchestrating planner, content,
+design, SEO and build agents. Each agent is represented by a dataclass with
+clear instructions. LangChain handles the prompt/response flow while OpenAI
+serves as the LLM backend. The pipeline writes the generated HTML to an output
+folder. This script assumes the ``OPENAI_API_KEY`` environment variable is set.
+
+The code is structured so it can be swapped out with OpenAI's official
+multi-agent API. See the ``run_with_openai_beta`` example at the bottom of the
+file for guidance.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Dict, Any, Callable
+
+from langchain.chains import LLMChain
+from langchain.chat_models import ChatOpenAI
+from langchain.prompts import PromptTemplate
+
+# ---------------------------------------------------------------------------
+# Base infrastructure
+# ---------------------------------------------------------------------------
+
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+llm = ChatOpenAI(temperature=0)
+
+
+def call_llm(prompt: str) -> str:
+    """Call the OpenAI model via LangChain with basic error handling."""
+    logger.info("LLM prompt:\n%s", prompt)
+    chain = LLMChain(llm=llm, prompt=PromptTemplate.from_template("{prompt}"))
+    try:
+        return chain.run(prompt=prompt)
+    except Exception as exc:  # noqa: BLE001
+        raise RuntimeError(f"LLM call failed: {exc}") from exc
+
+
+@dataclass
+class Agent:
+    """Simple representation of an agent with a name and template."""
+
+    name: str
+    template: str
+    process: Callable[[str], str] | None = None
+
+    def run(self, input_text: str) -> AgentResponse:
+        prompt = self.template.format(input=input_text)
+        content = call_llm(prompt) if self.process is None else self.process(prompt)
+        return AgentResponse(content)
+
+
+@dataclass
+class AgentResponse:
+    content: str
+    metadata: Dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# Agent definitions
+# ---------------------------------------------------------------------------
+
+PLANNER = Agent(
+    name="Planner",
+    template="Plan a website around the topic: {input}. Include sections and layout.",
+)
+
+CONTENT = Agent(
+    name="Content",
+    template="Generate detailed page content based on this plan: {input}",
+)
+
+DESIGN = Agent(
+    name="Design",
+    template=(
+        "Generate HTML and CSS for the following content. "
+        "Use accessible markup and responsive design: {input}"
+    ),
+)
+
+SEO = Agent(
+    name="SEO",
+    template="Improve the SEO metadata and structure for this HTML: {input}",
+)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline orchestration
+# ---------------------------------------------------------------------------
+
+def build_site(html: str, output_dir: str) -> None:
+    os.makedirs(output_dir, exist_ok=True)
+    path = os.path.join(output_dir, "index.html")
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(html)
+    logger.info("Website built at %s", path)
+
+
+def generate_website(topic: str, output_dir: str = "site_output") -> None:
+    plan = PLANNER.run(topic).content
+    content = CONTENT.run(plan).content
+    design = DESIGN.run(content).content
+    optimized = SEO.run(design).content
+    build_site(optimized, output_dir)
+
+
+# ---------------------------------------------------------------------------
+# Optional OpenAI Multi-Agent API demonstration
+# ---------------------------------------------------------------------------
+# The following demonstrates how this pipeline could be replaced by
+# OpenAI's official multi-agent API. Uncomment and adjust once you have an API
+# key and want to experiment with the beta assistants.
+#
+# import openai
+#
+# def run_with_openai_beta(topic: str, output_dir: str = "site_output") -> None:
+#     planner = openai.beta.assistants.create(
+#         name="Planner", instructions="Plan website layouts", model="gpt-4o"
+#     )
+#     content = openai.beta.assistants.create(
+#         name="Content", instructions="Write website copy", model="gpt-4o"
+#     )
+#     # Additional assistants would be created for design and SEO.
+#     # You would then use threads and runs to orchestrate communication
+#     # between these assistants and retrieve the final HTML.
+#     raise NotImplementedError
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Generate a website via multi-agent pipeline")
+    parser.add_argument("topic", help="Topic for the website")
+    parser.add_argument("--output", default="site_output", help="Directory for generated site")
+    args = parser.parse_args()
+
+    generate_website(args.topic, args.output)

--- a/sites/blog/index.html
+++ b/sites/blog/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Blog</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+    <nav class="navbar navbar-dark bg-dark">
+        <div class="container-fluid">
+            <span class="navbar-brand mb-0 h1">My Blog</span>
+        </div>
+    </nav>
+    <main class="container my-4">
+        <article class="mb-3">
+            <h2>First Post</h2>
+            <p>Welcome to this example blog generated with the multi-agent script.</p>
+        </article>
+        <article>
+            <h2>Second Post</h2>
+            <p>Another placeholder post.</p>
+        </article>
+    </main>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/sites/landing/index.html
+++ b/sites/landing/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Landing Page</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
+</head>
+<body>
+    <section class="hero is-primary">
+        <div class="hero-body">
+            <div class="container">
+                <h1 class="title">Awesome Product</h1>
+                <h2 class="subtitle">An example landing page generated with the multi-agent script.</h2>
+            </div>
+        </div>
+    </section>
+    <section class="section">
+        <div class="container">
+            <h3 class="title is-3">Features</h3>
+            <ul>
+                <li>Easy to use</li>
+                <li>Powered by AI</li>
+                <li>Deploy anywhere</li>
+            </ul>
+        </div>
+    </section>
+    <footer class="footer">
+        <div class="content has-text-centered">
+            &copy; 2024 Example
+        </div>
+    </footer>
+</body>
+</html>

--- a/sites/portfolio/index.html
+++ b/sites/portfolio/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Portfolio</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.3.5/dist/tailwind.min.css" rel="stylesheet">
+</head>
+<body class="bg-gray-100 text-gray-900">
+    <header class="p-4 bg-blue-700 text-white">
+        <h1 class="text-2xl font-bold">My Portfolio</h1>
+    </header>
+    <main class="p-4">
+        <section class="mb-6">
+            <h2 class="text-xl font-semibold">About Me</h2>
+            <p>This is a simple portfolio site generated as part of an AI multi-agent workflow.</p>
+        </section>
+        <section>
+            <h2 class="text-xl font-semibold">Projects</h2>
+            <ul class="list-disc ml-5">
+                <li>Project A</li>
+                <li>Project B</li>
+            </ul>
+        </section>
+    </main>
+    <footer class="p-4 text-center text-sm text-gray-600">
+        &copy; 2024 Example
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `sites/landing/` with a Bulma-based landing page
- mention the landing page in the README

## Testing
- `python -m py_compile multi_agent/link_chain.py && echo OK`


------
https://chatgpt.com/codex/tasks/task_e_68437ac927e88332b2b9b9e695372d4a